### PR TITLE
Jfurr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,5 +24,6 @@
     Updates:
     - No longer modify user settings.py file.  A seperate anouman_settings.py is created for the project
     - Set DEBUG=False
-    - Set ALLOWED_HOSTS=['domainname']
+    - Set ALLOWED_HOSTS=['domainname'] (even if ALLOWED_HOSTS is not currently present..ie older version)
     - Added --gunicorn-log-level command line option to set gunicorn log level.  Defaults to 'info'
+    

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@
 
 0.0.6.0
     Updates:
+    - No longer modify user settings.py file.  A seperate anouman_settings.py is created for the project
     - Set DEBUG=False
     - Set ALLOWED_HOSTS=['domainname']
-    - Added --gunicorn-log-level to set gunicorn log level.  Defaults to 'info'
-    - Created anouman_settings.py so the users settings.py didn't have to be modified
+    - Added --gunicorn-log-level command line option to set gunicorn log level.  Defaults to 'info'

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,3 +19,9 @@
 0.0.5.1
     Bugs:
         -Fixed documentation errors
+
+0.0.6.0
+    Updates:
+    - Set DEBUG=False
+    - Set ALLOWED_HOSTS=['domainname']
+    - Added --gunicorn-log-level to set gunicorn log level.  Defaults to 'info'

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,3 +25,4 @@
     - Set DEBUG=False
     - Set ALLOWED_HOSTS=['domainname']
     - Added --gunicorn-log-level to set gunicorn log level.  Defaults to 'info'
+    - Created anouman_settings.py so the users settings.py didn't have to be modified

--- a/anouman/bin/anouman
+++ b/anouman/bin/anouman
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # control whether we are working in test mode or not
-TEST=false
+TEST=true
 
 USER=`whoami`
 if [ $USER == 'root' ];

--- a/anouman/bin/anouman-admin.py
+++ b/anouman/bin/anouman-admin.py
@@ -51,6 +51,12 @@ def get_args():
         default=False,
     )
     
+    parser.add_argument('--gunicorn-log-level',
+        help='Set gunicorn loglevel:  debug, info, warn, error, critical',
+        dest='gunicorn_log_level',
+        default='info',
+    )
+
     parser.add_argument('--settings',
         help='Specify path to settings.py',
         dest='settings',

--- a/anouman/bin/anouman-admin.py
+++ b/anouman/bin/anouman-admin.py
@@ -45,7 +45,7 @@ def get_args():
         default='>=1.5, <=1.6',
     )
     
-    parser.add_argument('--django-project',
+    parser.add_argument('--django-project', 
         help='Create deployment for django project.  (Assumes one settings file and one wsgi file)',
         dest='django_project',
         default=False,

--- a/anouman/templates/gunicorn_start.sh
+++ b/anouman/templates/gunicorn_start.sh
@@ -19,7 +19,7 @@ exec {{GUNICORN}} {{DJANGO_WSGI_MODULE}}:application \
   --name {{NAME}} \
   --workers {{NUM_WORKERS}} \
   --user={{USER}} \
-  --log-level=debug  \
+  --log-level={{LOG_LEVEL}}  \
   --error-logfile {{ERROR_LOG}} \
   --access-logfile {{ACCESS_LOG}} \
   {% if DAEMON %} --daemon \{% endif %}

--- a/anouman/utils/find_files.py
+++ b/anouman/utils/find_files.py
@@ -128,22 +128,20 @@ def change_settings(settings_file, pattern, value):
     with  open(settings_file, 'r') as f:
         contents = f.readlines()
 
+    # Step 1.  Check file for property
     match_count = 0
     for line in contents:
         #if pattern in line and "#" not in line:
         if pattern in line[:len(pattern)]:
             match_count = match_count + 1
 
-    if match_count == 0:
-        print "ERROR  Property %s was not found in your settings file" %(pattern)
-        print "Anouman would prefer to have you set this value yourself or remove duplicate %s settings" %(pattern)
-        return False
     
     if match_count > 1:
         print "ERROR:  More than one %s line in settings file." %(pattern)
         print "Anouman would prefer to have you set this value yourself or remove duplicate %s settings" %(pattern)
         return False
 
+    # Step 2 Create new contents
     new_contents = []
     for line in contents:
         #if pattern in line and "#" not in line:
@@ -159,6 +157,16 @@ def change_settings(settings_file, pattern, value):
         else:
             new_contents.append(line)
 
+    # If the property wasn't found in Step 1 then we append it to the end of the file.
+    if match_count == 0:
+        if type(value) == str:
+            new_contents.append('%s="%s"\n'%(pattern, value) )
+        elif type(value) == bool or type(value) == list:
+            new_contents.append('%s=%s\n'%(pattern, value) )
+        else:
+            raise Exception("No match for: ", type(pattern))
+
+    # Step 3.  Write new contents to disk
     with open(settings_file, 'w') as f:
         f.writelines(new_contents)
 

--- a/anouman/utils/find_files.py
+++ b/anouman/utils/find_files.py
@@ -167,17 +167,3 @@ def change_settings(settings_file, pattern, value):
 
     return True
 
-def set_static_roots(args):
-    """
-        We need to change the STATIC_ROOT and MEDIA_ROOT variables
-    """
-    [settings_path, SETTINGS] = get_settings(args)
-    sys.path.append(os.path.dirname(settings_path))
-    import settings
-    
-    change_settings(settings_path, r'MEDIA_ROOT', "%s/"%(os.path.abspath("%s/media/" %(args.domainname))) )
-    change_settings(settings_path, r'STATIC_ROOT', "%s/"%(os.path.abspath("%s/static/" %(args.domainname))) )
-
-    reload(settings)
-
-    return [settings.STATIC_ROOT, settings.MEDIA_ROOT]

--- a/anouman/utils/find_files.py
+++ b/anouman/utils/find_files.py
@@ -130,21 +130,32 @@ def change_settings(settings_file, pattern, value):
 
     match_count = 0
     for line in contents:
-        if pattern in line and "#" not in line:
+        #if pattern in line and "#" not in line:
+        if pattern in line[:len(pattern)]:
             match_count = match_count + 1
 
+    if match_count == 0:
+        print "ERROR  Property %s was not found in your settings file" %(pattern)
+        print "Anouman would prefer to have you set this value yourself or remove duplicate %s settings" %(pattern)
+        return False
     
     if match_count > 1:
-        print "WARNING:  More than one %s line in settings file." %(pattern)
+        print "ERROR:  More than one %s line in settings file." %(pattern)
         print "Anouman would prefer to have you set this value yourself or remove duplicate %s settings" %(pattern)
         return False
 
     new_contents = []
     for line in contents:
-        if pattern in line and "#" not in line:
+        #if pattern in line and "#" not in line:
+        if pattern in line[:len(pattern)]:
             line = "#"+line
             new_contents.append(line)
-            new_contents.append('%s="%s"'%(pattern, value) )
+            if type(value) == str:
+                new_contents.append('%s="%s"\n'%(pattern, value) )
+            elif type(value) == bool or type(value) == list:
+                new_contents.append('%s=%s\n'%(pattern, value) )
+            else:
+                raise Exception("No match for: ", type(pattern))
         else:
             new_contents.append(line)
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,11 @@ from distutils.sysconfig import get_python_lib
 
 from setuptools import find_packages
 
-VERSION="0.0.5.1"
+VERSION="0.0.6.0"
 
 # Make sure README.rst is in sync with README.md  #*rst used by pypi and *md used by github
-os.system("pandoc --from=markdown --to=rst --output=README.rst README.md")
+try: os.system("pandoc --from=markdown --to=rst --output=README.rst README.md")
+except: pass 
 
 # Warn if we are installing over top of an existing installation. This can
 # cause issues where files that were deleted from a more recent Dnginx are


### PR DESCRIPTION
This PR addresses changes in the 0.5.4 which branch broke `get_real_instance_class()` for proxy models of polymorphic base classes

Consider the below model

```
class Catalog_Item(PolymorphicModel):
class Kit_Item(Catalog_Item):

class Stored_Catalog_Item(Catalog_Item):
    class Meta:
        proxy=True


# grab a Stored_Catalog_Item object that refers to a Kit_Item
stored_item = Stored_Catalog_Item.objects.get(id=1)
stored_item.get_real_instance() #  <= FAILS

# This works
stored_item = Catalog_Item.objects.get(id=1)
stored_item.get_real_instance()  # <=  FINE
```

this fails because of the call here 
https://github.com/chrisglass/django_polymorphic/blob/master/polymorphic/polymorphic_model.py#L113: `issubclass(model, self.__class__)`  where `model=Kit_Item` and `self.__class__=Stored_Catalog_Item` because `Kit_Item` isn't a child class of `Stored_Catalog_Item`, but rather`Catalog_Item`.

The fix I propose is actually pretty trivial in that it simply checks to see if `self.__class__` is a proxy model for a django polymorphic base class.:

```
if model is not None  \
and not issubclass(model, self.__class__) \
and not issubclass(model, self.__class__._meta.proxy_for_model):
```
